### PR TITLE
Add 'By' from selenium.webdriver.common in order to remove Deprecated Warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ nosetests.xml
 
 # Sample files(generated while execution)
 sample.png
+
+# Env variables
+.env

--- a/google-search-browserstack.py
+++ b/google-search-browserstack.py
@@ -3,6 +3,7 @@ import sys
 
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.by import By
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 try:
@@ -23,7 +24,7 @@ driver.get("http://www.google.com")
 if not "Google" in driver.title:
     raise Exception("Unable to load google page!")
 
-elem = driver.find_element_by_name("q")
+elem = driver.find_element(By.NAME, "q")
 elem.send_keys("selenium")
 elem.submit()
 

--- a/nose-test/google-search-browserstack.py
+++ b/nose-test/google-search-browserstack.py
@@ -4,6 +4,7 @@ import unittest
 
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.by import By
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 # Edit these to match your credentials
@@ -28,7 +29,7 @@ class PythonOrgSearch(unittest.TestCase):
     def test_search_in_python_org(self):
         driver = self.driver
         driver.get("http://www.google.com")
-        elem = driver.find_element_by_name("q")
+        elem = driver.find_element(By.NAME, "q")
         elem.send_keys("selenium")
         elem.submit()
         self.assertIn("Google", driver.title)

--- a/parallel_tests/run_parallel_tests.py
+++ b/parallel_tests/run_parallel_tests.py
@@ -20,4 +20,3 @@ for counter in range(num_of_tests):
 
 for counter in range(num_of_tests):
 	process[counter].wait()
-

--- a/parallel_tests/test.py
+++ b/parallel_tests/test.py
@@ -1,4 +1,5 @@
 from selenium import webdriver
+from selenium.webdriver.common.by import By
 import os, sys, json
 
 try:
@@ -38,7 +39,7 @@ driver = webdriver.Remote(
 )
 
 driver.get("http://www.google.com")
-inputElement = driver.find_element_by_name("q")
+inputElement = driver.find_element(By.NAME, "q")
 inputElement.send_keys("browserstack")
 inputElement.submit()
 print(driver.title)

--- a/py.test/google-search-browserstack.py
+++ b/py.test/google-search-browserstack.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from selenium import webdriver
+from selenium.webdriver.common.by import By
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 # Edit these to match your credentials
@@ -21,7 +22,7 @@ def test_run():
 
     if not "Google" in driver.title:
         raise Exception("Are you not on google? How come!")
-        elem = driver.find_element_by_name("q")
+        elem = driver.find_element(By.NAME, "q")
         elem.send_keys("selenium")
         elem.submit()
         driver.quit()

--- a/screenshot-sample.py
+++ b/screenshot-sample.py
@@ -8,6 +8,7 @@
 import sys
 import base64
 from selenium import webdriver
+from selenium.webdriver.common.by import By
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.remote.webdriver import WebDriver
 
@@ -51,7 +52,7 @@ driver = webdriver.Remote(
 )
 
 driver.get("http://www.google.com")
-inputElement = driver.find_element_by_name("q")
+inputElement = driver.find_element(By.NAME, "q")
 inputElement.send_keys("browserstack")
 inputElement.submit()
 print(driver.title)

--- a/unittest/google-search-browserstack.py
+++ b/unittest/google-search-browserstack.py
@@ -4,6 +4,7 @@ import unittest
 
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.by import By
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 try:
@@ -22,13 +23,13 @@ class PythonOrgSearch(unittest.TestCase):
 
         self.driver = webdriver.Remote(
             command_executor=url,
-            desired_capabilities=DesiredCapabilities.FIREFOX
+            #desired_capabilities=DesiredCapabilities.FIREFOX
         )
 
     def test_search_in_python_org(self):
         driver = self.driver
         driver.get("http://www.google.com")
-        elem = driver.find_element_by_name("q")
+        elem = driver.find_element(By.NAME, "q")
         elem.send_keys("selenium")
         elem.submit()
         self.assertIn("Google", driver.title)


### PR DESCRIPTION
Add 'By' from selenium.webdriver.common in order to remove Deprecated Warning from recent Selenium versions.